### PR TITLE
feat: add shell auto-commit action

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# Auto Commit Action
+
+Automatically commit changes made during a GitHub Actions workflow and push them back to the repository.
+
+## Features
+
+- Detects modified files during a workflow run.
+- Commits them with a customizable commit message.
+- Pushes the commit to the branch that triggered the workflow.
+- Co-authors the commit with the author of the last commit.
+- Skips committing when no matching changes are found.
+- Restricts commits to an optional glob filter to avoid unintended files.
+
+## Usage
+
+```yaml
+steps:
+  - uses: actions/checkout@v4
+    with:
+      fetch-depth: 0
+  # ... other steps that make changes ...
+  - uses: ./
+    with:
+      commit-message: "chore: update files"
+      filter: |
+        docs/**
+        *.md
+```
+
+By default, the commit message is `chore: automated update`.
+If `filter` is empty or not provided, all changes are considered.

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,21 @@
+name: 'Auto Commit'
+description: 'Automatically commit changes and push back to the repository with co-author.'
+author: 'GitHub Actions'
+inputs:
+  commit-message:
+    description: 'Commit message for the changes.'
+    required: false
+    default: 'chore: automated update'
+  filter:
+    description: 'Newline-separated list of glob patterns to allow.'
+    required: false
+    default: ''
+runs:
+  using: 'composite'
+  steps:
+    - name: Commit changes
+      shell: bash
+      env:
+        FILTER: ${{ inputs.filter }}
+      run: |
+        ${{ github.action_path }}/auto-commit.sh "${{ inputs.commit-message }}"

--- a/auto-commit.sh
+++ b/auto-commit.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+COMMIT_MESSAGE=${1:-"chore: automated update"}
+
+# Build an array of file patterns from FILTER env (newline separated)
+FILTERS=()
+if [[ -n "${FILTER:-}" ]]; then
+  while IFS= read -r line; do
+    [[ -n "$line" ]] && FILTERS+=("$line")
+  done <<< "${FILTER}"
+fi
+if [[ ${#FILTERS[@]} -eq 0 ]]; then
+  FILTERS=(".")
+fi
+
+git config user.name "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+if [[ -n $(git status --porcelain -- "${FILTERS[@]}") ]]; then
+  git add -- "${FILTERS[@]}"
+  last_author=$(git log -1 --pretty=format:'%an <%ae>')
+  git commit -m "$COMMIT_MESSAGE"$'\n\n'"Co-authored-by: $last_author"
+  git push
+else
+  echo "No changes to commit."
+fi


### PR DESCRIPTION
## Summary
- add glob pattern filtering and change detection to auto-commit script
- expose `filter` input in composite action and document usage

## Testing
- `shellcheck auto-commit.sh`
- `bash -n auto-commit.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b5d930e538832fa4460d6764583b4a